### PR TITLE
feat: add accessible side navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,46 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Slakt på Öland Mark III
 
-## Getting Started
+This is a [Next.js](https://nextjs.org) project.
 
-First, run the development server:
+## Side Navigation
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+A responsive left navigation rail is available across the site.
+It collapses into a drawer on smaller viewports and
+supports nested groups, keyboard navigation and active route highlighting.
+
+### Adding links
+
+Edit `src/lib/nav.ts` and update the `navItems` array:
+
+```ts
+export const navItems: NavItem[] = [
+  { title: 'Start', href: '/start' },
+  {
+    title: 'Resources',
+    children: [
+      { title: 'Setting', href: '/setting' },
+      { title: 'Characters', href: '/characters' },
+    ],
+  },
+  { title: 'GitHub', href: 'https://github.com/drbrago/slakt-pa-oland-mark-iii', external: true },
+];
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Each item accepts:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- `title` – link label.
+- `href` – optional URL; omit for group headers.
+- `children` – nested `NavItem[]` for collapsible groups.
+- `icon` – optional React node shown before the title.
+- `external` – renders with `target="_blank"` and `rel="noopener noreferrer"`.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Testing
 
-## Learn More
+- **Unit tests:** `npm test`
+- **E2E tests:** `npm run test:e2e`
 
-To learn more about Next.js, take a look at the following resources:
+## How to extend the menu
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Add routes or groups in `src/lib/nav.ts`.
+2. Server components import the array and pass it to `SideNav`.
+3. The component handles collapsible state and highlights active links automatically.

--- a/__tests__/sidenav.test.tsx
+++ b/__tests__/sidenav.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SideNav from '@/components/SideNav/SideNav';
+import type { NavItem } from '@/lib/nav';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/start',
+}));
+
+const items: NavItem[] = [
+  { title: 'Start', href: '/start' },
+  {
+    title: 'Docs',
+    children: [{ title: 'Intro', href: '/docs/intro' }],
+  },
+];
+
+describe('SideNav', () => {
+  it('marks active link', () => {
+    render(<SideNav items={items} variant="rail" />);
+    expect(
+      screen.getByRole('link', { name: 'Start' })
+    ).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('toggles group', () => {
+    render(<SideNav items={items} variant="rail" />);
+    const button = screen.getByRole('button', { name: 'Docs' });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/e2e/sidenav.spec.ts
+++ b/e2e/sidenav.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('sidenav drawer', () => {
+  test('opens and navigates via drawer', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('link', { name: 'Setting' }).click();
+    await page.waitForURL('**/setting');
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await expect(page.getByRole('link', { name: 'Setting' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import nextJest from 'next/jest';
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+export default createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.11",
@@ -32,6 +34,12 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.4.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.11",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@playwright/test": "^1.45.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,4 +44,12 @@ body::before {
   --prose-body: var(--color-albescent-white-100);
   --prose-headings: var(--color-albescent-white-100);
   --prose-bold: var(--color-albescent-white-200);
+  --rail-w: 280px;
+  --nav-transition: 300ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --nav-transition: 0ms;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import { Bebas_Neue, Roboto_Slab } from "next/font/google";
 import "./globals.css";
+import React from "react";
+import { usePathname } from "next/navigation";
+import { navItems, NavItem } from "@/lib/nav";
+import SideNav from "@/components/SideNav/SideNav";
+import OverlayDrawer from "@/components/OverlayDrawer";
 
 const bebasNeue = Bebas_Neue({
   subsets: ["latin"],
@@ -25,15 +30,59 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="sv" className={`${bebasNeue.variable} ${robotoSlab.variable}`}>
-      <body className="bg-ink">
+      <body className="bg-ink text-albescent-white-100">
         <a
           href="#main-content"
           className="sr-only z-50 focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:bg-albescent-white-100 focus:text-blood focus:p-2 focus:rounded"
         >
           Hoppa till huvudinnehållet
         </a>
-        {children}
+        <ClientShell items={navItems}>{children}</ClientShell>
       </body>
     </html>
+  );
+}
+
+function ClientShell({
+  items,
+  children,
+}: {
+  items: NavItem[];
+  children: React.ReactNode;
+}) {
+  "use client";
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
+  React.useEffect(() => setOpen(false), [pathname]);
+  return (
+    <>
+      <div className="lg:grid lg:grid-cols-[var(--rail-w)_1fr] min-h-screen">
+        <SideNav items={items} variant="rail" className="hidden lg:block bg-blood text-albescent-white-100" />
+        <div className="flex flex-col min-h-screen">
+          <header className="lg:hidden bg-blood p-4">
+            <button
+              ref={triggerRef}
+              onClick={() => setOpen(true)}
+              aria-label="Open menu"
+              className="p-2 text-albescent-white-100 focus:outline-none focus:ring-2 focus:ring-albescent-white-100"
+            >
+              ☰
+            </button>
+          </header>
+          {children}
+        </div>
+      </div>
+      <OverlayDrawer
+        isOpen={open}
+        onClose={() => {
+          setOpen(false);
+          triggerRef.current?.focus();
+        }}
+        label="Primary navigation"
+      >
+        <SideNav items={items} variant="drawer" />
+      </OverlayDrawer>
+    </>
   );
 }

--- a/src/components/OverlayDrawer.tsx
+++ b/src/components/OverlayDrawer.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  label: string;
+  children: ReactNode;
+}
+
+export default function OverlayDrawer({ isOpen, onClose, label, children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? 'hidden' : '';
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        className="relative bg-ink text-albescent-white-100 w-[var(--rail-w)] max-w-full h-full p-4 flex flex-col"
+      >
+        <button
+          onClick={onClose}
+          aria-label="Close menu"
+          className="self-end mb-4 p-2 focus:outline-none focus:ring-2 focus:ring-blood"
+        >
+          ✕
+        </button>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/SideNav/NavGroup.tsx
+++ b/src/components/SideNav/NavGroup.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+interface Props {
+  id: string;
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+  active?: boolean;
+}
+
+export default function NavGroup({
+  id,
+  title,
+  expanded,
+  onToggle,
+  children,
+  active,
+}: Props) {
+  const reduced = useReducedMotion();
+  const buttonClasses = `flex w-full items-center justify-between px-4 py-2 border-l-2 ${
+    active
+      ? 'font-bold border-blood'
+      : 'border-transparent hover:border-albescent-white-400'
+  }`;
+  return (
+    <div>
+      <button
+        aria-controls={id}
+        aria-expanded={expanded}
+        onClick={onToggle}
+        className={buttonClasses}
+      >
+        <span>{title}</span>
+        <span aria-hidden="true" className="ml-2">
+          {expanded ? '−' : '+'}
+        </span>
+      </button>
+      <div
+        id={id}
+        className="overflow-hidden"
+        style={{
+          maxHeight: expanded ? '1000px' : '0',
+          transition: reduced ? 'none' : 'max-height var(--nav-transition) ease',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SideNav/NavLink.tsx
+++ b/src/components/SideNav/NavLink.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface Props {
+  href: string;
+  children: ReactNode;
+  active?: boolean;
+  external?: boolean;
+}
+
+export default function NavLink({ href, children, active, external }: Props) {
+  const base = 'flex items-center gap-2 px-4 py-2 border-l-2';
+  const state = active
+    ? 'font-bold border-blood text-albescent-white-100'
+    : 'border-transparent text-albescent-white-300 hover:border-albescent-white-400 hover:text-albescent-white-100';
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} ${state}`}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className={`${base} ${state}`}
+      aria-current={active ? 'page' : undefined}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState, useCallback, ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import NavLink from './NavLink';
+import NavGroup from './NavGroup';
+import { NavItem } from '@/lib/nav';
+
+interface Props {
+  items: NavItem[];
+  variant: 'rail' | 'drawer';
+  className?: string;
+}
+
+const STORAGE_KEY = 'sidenav:state';
+
+export default function SideNav({ items, variant, className }: Props) {
+  const pathname = usePathname();
+  const [openState, setOpenState] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      setOpenState(stored);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(openState));
+  }, [openState]);
+
+  const isItemActive = useCallback(
+    (item: NavItem): boolean => {
+      if (item.href && (pathname === item.href || pathname.startsWith(item.href + '/')))
+        return true;
+      return item.children ? item.children.some(isItemActive) : false;
+    },
+    [pathname]
+  );
+
+  function renderItems(nodes: NavItem[]): ReactNode {
+    return (
+      <ul className="space-y-1">
+        {nodes.map((item) => {
+          const id = item.title.toLowerCase().replace(/\s+/g, '-');
+          const active = isItemActive(item);
+          const expanded = item.children ? openState[id] || active : false;
+
+          if (item.children) {
+            return (
+              <li key={id}>
+                <NavGroup
+                  id={id}
+                  title={item.title}
+                  expanded={expanded}
+                  onToggle={() =>
+                    setOpenState((s) => ({ ...s, [id]: !expanded }))
+                  }
+                  active={active}
+                >
+                  {renderItems(item.children)}
+                </NavGroup>
+              </li>
+            );
+          }
+
+          return (
+            <li key={id}>
+              <NavLink href={item.href!} active={active} external={item.external}>
+                {item.icon}
+                <span>{item.title}</span>
+              </NavLink>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  const widthClass = variant === 'rail' ? 'w-[var(--rail-w)]' : 'w-full';
+
+  return (
+    <nav
+      aria-label="Primary"
+      className={`${widthClass} ${
+        variant === 'rail' ? 'h-screen overflow-y-auto sticky top-0' : ''
+      } ${className ?? ''}`}
+    >
+      {renderItems(items)}
+    </nav>
+  );
+}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const FOCUSABLE =
+  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(ref: React.RefObject<HTMLElement>, active: boolean) {
+  useEffect(() => {
+    if (!active || !ref.current) return;
+    const node = ref.current;
+    const focusables = Array.from(
+      node.querySelectorAll<HTMLElement>(FOCUSABLE)
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener('keydown', handleKey);
+    first.focus();
+    return () => node.removeEventListener('keydown', handleKey);
+  }, [ref, active]);
+}

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  return reduced;
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,38 @@
+import { ReactNode, createElement } from 'react';
+
+export type NavItem = {
+  title: string;
+  href?: string;
+  icon?: ReactNode;
+  children?: NavItem[];
+  external?: boolean;
+};
+
+const HomeIcon = createElement(
+  'svg',
+  {
+    viewBox: '0 0 24 24',
+    className: 'h-4 w-4 mr-2',
+    'aria-hidden': 'true',
+    fill: 'currentColor',
+  },
+  createElement('path', {
+    d: 'M3 10.5 12 3l9 7.5V21a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1v-10.5Z',
+  })
+);
+
+export const navItems: NavItem[] = [
+  { title: 'Start', href: '/start', icon: HomeIcon },
+  {
+    title: 'Resources',
+    children: [
+      { title: 'Setting', href: '/setting' },
+      { title: 'Characters', href: '/characters' },
+    ],
+  },
+  {
+    title: 'GitHub',
+    href: 'https://github.com/drbrago/slakt-pa-oland-mark-iii',
+    external: true,
+  },
+];


### PR DESCRIPTION
## Summary
- add responsive SideNav with collapsible groups and drawer behaviour
- provide overlay drawer, focus-trap hooks and nav data model
- document usage and add Jest/Playwright tests

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*
- `npx playwright test` *(fails: 403 fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689c52d8fe1c832a8a52c10a6f2dff91